### PR TITLE
use traditional index for loop to prevent new iterator instance being…

### DIFF
--- a/src/org/elapsed/sponge/listeners/SpongeListener.java
+++ b/src/org/elapsed/sponge/listeners/SpongeListener.java
@@ -1,5 +1,7 @@
 package org.elapsed.sponge.listeners;
 
+import java.util.List;
+
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
@@ -41,8 +43,11 @@ public class SpongeListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onExplode(final EntityExplodeEvent event) {
-        for (int i = 0; i < event.blockList().size(); i++) {
-            final Block block = event.blockList().get(i);
+        final List<Block> blockList = event.blockList();
+        final int size = blockList.size();
+
+        for (int i = 0; i < size; i++) {
+            final Block block = blockList.get(i);
             if (block.getType() == Material.SPONGE) {
                 this.sponges.unsponge(block);
             }

--- a/src/org/elapsed/sponge/listeners/SpongeListener.java
+++ b/src/org/elapsed/sponge/listeners/SpongeListener.java
@@ -41,7 +41,8 @@ public class SpongeListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onExplode(final EntityExplodeEvent event) {
-        for (final Block block : event.blockList()) {
+        for (int i = 0; i < event.blockList().size(); i++) {
+            final Block block = event.blockList().get(i);
             if (block.getType() == Material.SPONGE) {
                 this.sponges.unsponge(block);
             }


### PR DESCRIPTION
… created - event#blockList#size times.

This is a **micro-optimization**.

Java 8 does feature **escape analysis** but it is better the explicitly prevent excess garbage rather than rely on the feature.

(Deleted fork - had to create new PR)